### PR TITLE
Get away from master/slave terminology

### DIFF
--- a/venv/lib/python3.5/site-packages/joblib/pool.py
+++ b/venv/lib/python3.5/site-packages/joblib/pool.py
@@ -485,11 +485,11 @@ class MemmapingPool(PicklingPool):
         Memmapping mode for numpy arrays passed to workers.
         See 'max_nbytes' parameter documentation for more details.
     forward_reducers: dictionary, optional
-        Reducers used to pickle objects passed from master to worker
+        Reducers used to pickle objects passed from main to worker
         processes: see below.
     backward_reducers: dictionary, optional
         Reducers used to pickle return values from workers back to the
-        master process.
+        main process.
     verbose: int, optional
         Make it possible to monitor how the communication of numpy arrays
         with the subprocess is handled (pickling or memmaping)

--- a/venv/lib/python3.5/site-packages/joblib/test/common.py
+++ b/venv/lib/python3.5/site-packages/joblib/test/common.py
@@ -55,7 +55,7 @@ except ImportError:
     memory_usage = memory_used = None
 
 # A utility to kill the test runner in case a multiprocessing assumption
-# triggers an infinite wait on a pipe by the master process for one of its
+# triggers an infinite wait on a pipe by the main process for one of its
 # failed workers
 
 _KILLER_THREADS = dict()

--- a/venv/lib/python3.5/site-packages/numpy/distutils/system_info.py
+++ b/venv/lib/python3.5/site-packages/numpy/distutils/system_info.py
@@ -108,7 +108,7 @@ include_dirs = /usr/X11R6/include
 
 Authors:
   Pearu Peterson <pearu@cens.ioc.ee>, February 2002
-  David M. Cooke <cookedm@physics.mcmaster.ca>, April 2002
+  David M. Cooke <cookedm@physics.mcmain.ca>, April 2002
 
 Copyright 2002 Pearu Peterson all rights reserved,
 Pearu Peterson <pearu@cens.ioc.ee>

--- a/venv/lib/python3.5/site-packages/numpy/testing/nose_tools/nosetester.py
+++ b/venv/lib/python3.5/site-packages/numpy/testing/nose_tools/nosetester.py
@@ -414,7 +414,7 @@ class NoseTester(object):
 
         # reset doctest state on every run
         import doctest
-        doctest.master = None
+        doctest.main = None
 
         if raise_warnings is None:
             raise_warnings = self.raise_warnings

--- a/venv/lib/python3.5/site-packages/pandas/io/pytables.py
+++ b/venv/lib/python3.5/site-packages/pandas/io/pytables.py
@@ -2391,7 +2391,7 @@ class GenericFixed(Fixed):
 
     def _alias_to_class(self, alias):
         if isinstance(alias, type):  # pragma: no cover
-            # compat: for a short period of time master stored types
+            # compat: for a short period of time main stored types
             return alias
         return self._reverse_index_map.get(alias, Index)
 

--- a/venv/lib/python3.5/site-packages/pandas/io/sql.py
+++ b/venv/lib/python3.5/site-packages/pandas/io/sql.py
@@ -1517,7 +1517,7 @@ class SQLiteDatabase(PandasSQL):
         # esc_name = escape(name)
 
         wld = '?'
-        query = ("SELECT name FROM sqlite_master "
+        query = ("SELECT name FROM sqlite_main "
                  "WHERE type='table' AND name=%s;") % wld
 
         return len(self.execute(query, [name, ]).fetchall()) > 0

--- a/venv/lib/python3.5/site-packages/pandas/tests/io/generate_legacy_storage_files.py
+++ b/venv/lib/python3.5/site-packages/pandas/tests/io/generate_legacy_storage_files.py
@@ -25,7 +25,7 @@ generate_legacy_storage_files with an *older* version of pandas to
 generate a pickle file. We will then check this file into a current
 branch, and test using test_pickle.py. This will load the *older*
 pickles and test versus the current data that is generated
-(with master). These are then compared.
+(with main). These are then compared.
 
 If we have cases where we changed the signature (e.g. we renamed
 offset -> freq in Timestamp). Then we have to conditionally execute

--- a/venv/lib/python3.5/site-packages/pandas/tests/io/test_sql.py
+++ b/venv/lib/python3.5/site-packages/pandas/tests/io/test_sql.py
@@ -219,7 +219,7 @@ class SQLiteMixIn(MixInBase):
 
     def _get_all_tables(self):
         c = self.conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='table'")
+            "SELECT name FROM sqlite_main WHERE type='table'")
         return [table[0] for table in c.fetchall()]
 
     def _close_conn(self):
@@ -1990,7 +1990,7 @@ class TestSQLiteFallback(SQLiteMixIn, PandasSQLTest):
 
     def _get_index_columns(self, tbl_name):
         ixs = sql.read_sql_query(
-            "SELECT * FROM sqlite_master WHERE type = 'index' " +
+            "SELECT * FROM sqlite_main WHERE type = 'index' " +
             "AND tbl_name = '%s'" % tbl_name, self.conn)
         ix_cols = []
         for ix_name in ixs.name:

--- a/venv/lib/python3.5/site-packages/pip-9.0.1-py3.5.egg/pip/_vendor/pkg_resources/__init__.py
+++ b/venv/lib/python3.5/site-packages/pip-9.0.1-py3.5.egg/pip/_vendor/pkg_resources/__init__.py
@@ -644,9 +644,9 @@ class WorkingSet(object):
             self.add_entry(entry)
 
     @classmethod
-    def _build_master(cls):
+    def _build_main(cls):
         """
-        Prepare the master working set.
+        Prepare the main working set.
         """
         ws = cls()
         try:
@@ -3016,9 +3016,9 @@ def _initialize(g=globals()):
 
 
 @_call_aside
-def _initialize_master_working_set():
+def _initialize_main_working_set():
     """
-    Prepare the master working set and make the ``require()``
+    Prepare the main working set and make the ``require()``
     API available.
 
     This function has explicit effects on the global state
@@ -3028,7 +3028,7 @@ def _initialize_master_working_set():
     Invocation by other packages is unsupported and done
     at their own risk.
     """
-    working_set = WorkingSet._build_master()
+    working_set = WorkingSet._build_main()
     _declare_state('object', working_set=working_set)
 
     require = working_set.require

--- a/venv/lib/python3.5/site-packages/pip-9.0.1-py3.5.egg/pip/vcs/git.py
+++ b/venv/lib/python3.5/site-packages/pip-9.0.1-py3.5.egg/pip/vcs/git.py
@@ -118,7 +118,7 @@ class Git(VersionControl):
             self.run_command(['fetch', '-q', '--tags'], cwd=dest)
         else:
             self.run_command(['fetch', '-q'], cwd=dest)
-        # Then reset to wanted revision (maybe even origin/master)
+        # Then reset to wanted revision (maybe even origin/main)
         if rev_options:
             rev_options = self.check_rev_options(
                 rev_options[0], dest, rev_options,
@@ -133,7 +133,7 @@ class Git(VersionControl):
             rev_options = [rev]
             rev_display = ' (to %s)' % rev
         else:
-            rev_options = ['origin/master']
+            rev_options = ['origin/main']
             rev_display = ''
         if self.check_destination(dest, url, rev_options, rev_display):
             logger.info(


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.